### PR TITLE
ECS - Optional Queries

### DIFF
--- a/ecs/src/lib.rs
+++ b/ecs/src/lib.rs
@@ -324,14 +324,17 @@ mod tests {
             ComponentQuery {
                 id: a,
                 mutable: true,
+                optional: false,
             },
             ComponentQuery {
                 id: b,
                 mutable: false,
+                optional: false,
             },
             ComponentQuery {
                 id: b,
                 mutable: false,
+                optional: false,
             },
         ]);
         assert!(q.is_ok(), "{:?}; a={:?}, b={:?}", q, a, b);
@@ -350,14 +353,17 @@ mod tests {
                 ComponentQuery {
                     id: a,
                     mutable: false,
+                    optional: false,
                 },
                 ComponentQuery {
                     id: b,
                     mutable: true,
+                    optional: false,
                 },
                 ComponentQuery {
                     id: b,
                     mutable: false,
+                    optional: false,
                 }
             ])
         );
@@ -377,30 +383,42 @@ mod tests {
         let usize_query = Query::new(vec![ComponentQuery {
             id: usize_id,
             mutable: false,
+            optional: false,
         }])
         .unwrap();
         let both_query = Query::new(vec![
             ComponentQuery {
                 id: usize_id,
                 mutable: true,
+                optional: false,
             },
             ComponentQuery {
                 id: f32_id,
                 mutable: false,
+                optional: false,
             },
         ])
         .unwrap();
         {
             let mut res = world.query(&usize_query);
-            assert_eq!(*unsafe { res.get(a)[0].cast::<usize>().as_ref() }, 0);
-            assert_eq!(*unsafe { res.get(b)[0].cast::<usize>().as_ref() }, 1);
+            assert_eq!(
+                *unsafe { res.get(a)[0].cast::<usize>().as_ref().unwrap() },
+                0
+            );
+            assert_eq!(
+                *unsafe { res.get(b)[0].cast::<usize>().as_ref().unwrap() },
+                1
+            );
         }
         {
             let mut res = world.query(&both_query);
             assert!(unsafe { res.try_get(a) }.is_none());
             let (int, float) = unsafe {
                 if let [int, float] = res.get(b)[..] {
-                    (int.cast::<usize>().as_mut(), float.cast::<f32>().as_ref())
+                    (
+                        int.cast::<usize>().as_mut().unwrap(),
+                        float.cast::<f32>().as_ref().unwrap(),
+                    )
                 } else {
                     panic!()
                 }
@@ -410,8 +428,14 @@ mod tests {
         }
         {
             let mut res = world.query(&usize_query);
-            assert_eq!(*unsafe { res.get(a)[0].cast::<usize>().as_ref() }, 0);
-            assert_eq!(*unsafe { res.get(b)[0].cast::<usize>().as_ref() }, 3);
+            assert_eq!(
+                *unsafe { res.get(a)[0].cast::<usize>().as_ref().unwrap() },
+                0
+            );
+            assert_eq!(
+                *unsafe { res.get(b)[0].cast::<usize>().as_ref().unwrap() },
+                3
+            );
         }
     }
 
@@ -430,16 +454,19 @@ mod tests {
         let name_query = Query::new(vec![ComponentQuery {
             id: world.component_registry().id::<Name>().unwrap(),
             mutable: false,
+            optional: false,
         }])
         .unwrap();
         let mut_name_query = Query::new(vec![ComponentQuery {
             id: world.component_registry().id::<Name>().unwrap(),
             mutable: true,
+            optional: false,
         }])
         .unwrap();
         let health_query = Query::new(vec![ComponentQuery {
             id: world.component_registry().id::<Health>().unwrap(),
             mutable: true,
+            optional: false,
         }])
         .unwrap();
         let r1 = world.query(&name_query);
@@ -478,16 +505,19 @@ mod tests {
             ComponentQuery {
                 id: name_id,
                 mutable: true,
+                optional: false,
             },
             ComponentQuery {
                 id: health_id,
                 mutable: false,
+                optional: false,
             },
         ])
         .unwrap();
         let q2 = Query::new(vec![ComponentQuery {
             id: health_id,
             mutable: true,
+            optional: false,
         }])
         .unwrap();
 
@@ -582,10 +612,12 @@ mod tests {
             ComponentQuery {
                 id: pos_id,
                 mutable: true,
+                optional: false,
             },
             ComponentQuery {
                 id: vel_id,
                 mutable: false,
+                optional: false,
             },
         ])
         .unwrap();
@@ -594,8 +626,8 @@ mod tests {
             q.iter().map(|(_e, comps)| {
                 if let [pos, vel] = comps[..] {
                     (
-                        pos.cast::<Position>().as_mut(),
-                        vel.cast::<Velocity>().as_ref(),
+                        pos.cast::<Position>().as_mut().unwrap(),
+                        vel.cast::<Velocity>().as_ref().unwrap(),
                     )
                 } else {
                     panic!();
@@ -609,6 +641,7 @@ mod tests {
         let q = Query::new(vec![ComponentQuery {
             id: pos_id,
             mutable: false,
+            optional: false,
         }])
         .unwrap();
         let mut q = world.query(&q);
@@ -616,7 +649,7 @@ mod tests {
             q.iter()
                 .map(|(_e, comps)| {
                     if let [pos] = comps[..] {
-                        pos.cast::<Position>().as_ref()
+                        pos.cast::<Position>().as_ref().unwrap()
                     } else {
                         panic!();
                     }
@@ -667,7 +700,12 @@ mod tests {
         let id = world.component_registry_mut().register::<usize>();
         let entity = world.spawn();
 
-        let q = Query::new(vec![ComponentQuery { id, mutable: true }]).unwrap();
+        let q = Query::new(vec![ComponentQuery {
+            id,
+            mutable: true,
+            optional: false,
+        }])
+        .unwrap();
         // This creates a mutable borrow on `usize`s
         let q = world.query(&q);
         // And this another one
@@ -861,6 +899,101 @@ mod tests {
         }
 
         assert_eq!(counter.get(), 0);
+    }
+
+    #[test]
+    fn cannot_get_component_of_old_entity() {
+        let mut world = World::default();
+
+        let a = world.spawn();
+        world.despawn(a);
+        let b = world.spawn();
+        world.add(b, 10usize);
+        let q = Query::new(vec![ComponentQuery {
+            id: world.component_registry().id::<usize>().unwrap(),
+            mutable: false,
+            optional: true,
+        }])
+        .unwrap();
+        let mut res = world.query(&q);
+        assert!(unsafe { res.try_get(a).is_none() });
+        assert!(unsafe { res.try_get(b).is_some() });
+    }
+
+    #[test]
+    fn optional_query() {
+        let mut world = World::default();
+
+        struct A;
+        struct B(usize);
+
+        for i in 0..=100 {
+            let e = world.spawn();
+            world.add(e, A);
+            if i % 2 == 0 {
+                world.add(e, B(0));
+            }
+        }
+
+        let mut with_b = 0;
+        let mut without_b = 0;
+        query_iter!(world, (entity: Entity, a: A, b: mut Option<B>) => {
+            if let Some(b) = b {
+                b.0 += 1;
+                with_b += 1;
+            } else {
+                without_b += 1;
+            }
+        });
+        assert_eq!(with_b, 51);
+        assert_eq!(without_b, 50);
+        let mut with_b = 0;
+        let mut without_b = 0;
+        query_iter!(world, (a: A, b: Option<B>) => {
+            if let Some(b) = b {
+                with_b += 1;
+            } else {
+                without_b += 1;
+            }
+        });
+        assert_eq!(with_b, 51);
+        assert_eq!(without_b, 50);
+
+        query_iter!(world, (b: B) => {
+            assert_eq!(b.0, 1);
+        });
+    }
+
+    #[test]
+    fn optional_combs_query() {
+        let mut world = World::default();
+        struct A;
+
+        for _ in 0..10 {
+            let e = world.spawn();
+            world.add(e, A);
+        }
+        for _ in 0..10 {
+            world.spawn();
+        }
+
+        let mut c = 0;
+        query_iter_combs!(world, (_: A) => {
+            c += 1;
+        });
+        assert_eq!(c, 10 * 9 / 2);
+
+        let mut c = 0;
+        query_iter_combs!(world, (_: Option<A>) => {
+            c += 1;
+        });
+        assert_eq!(c, 20 * 19 / 2);
+
+        let mut c = 0;
+        query_iter_combs!(world, (_: mut Option<A>) => {
+            c += 1;
+        });
+        assert_eq!(c, 20 * 19 / 2);
     }
 
     #[derive(Debug)]

--- a/ecs/src/query/macros.rs
+++ b/ecs/src/query/macros.rs
@@ -1,5 +1,3 @@
-use std::ptr::NonNull;
-
 #[macro_export]
 macro_rules! query_iter {
     ( $world:expr, $commands:ident: Commands, ($($query:tt)*) => $body:block ) => {{
@@ -29,6 +27,14 @@ macro_rules! query_iter {
 
 #[macro_export]
 macro_rules! query_iter_combs {
+    ( $world:expr, $commands:ident: Commands, ($($query:tt)*) => $body:block ) => {{
+        let mut command_buffer = $crate::CommandBuffer::new();
+        let mut $commands = $crate::Commands::new(&mut command_buffer, $world.entities());
+
+        query_iter_combs!($world, ($($query)*) => $body);
+
+        command_buffer.apply(&mut $world);
+    }};
     ( $world:expr, ($($query:tt)*) => $body:block ) => {{
         #[allow(unused_mut)]
         let mut v = vec![];
@@ -49,50 +55,106 @@ macro_rules! query_iter_combs {
 
 #[macro_export]
 macro_rules! _query_definition {
+    // entity
     ( $world:expr, $vec:expr, ($name:tt: Entity, $($tail:tt)*) ) => {{
         _query_definition!($world, $vec, ($($tail)*));
     }};
+    // opt
+    ( $world:expr, $vec:expr, ($name:tt: Option<$type:ty>, $($tail:tt)*) ) => {{
+        $vec.push(ComponentQuery {
+            id: $world.component_registry().id::<$type>().unwrap(),
+            mutable: false,
+            optional: false,
+        });
+        _query_definition!($world, $vec, ($($tail)*));
+    }};
+    // opt mut
+    ( $world:expr, $vec:expr, ($name:tt: mut Option<$type:ty>, $($tail:tt)*) ) => {{
+        $vec.push(ComponentQuery {
+            id: $world.component_registry().id::<$type>().unwrap(),
+            mutable: true,
+            optional: true,
+        });
+        _query_definition!($world, $vec, ($($tail)*));
+    }};
+    // comp
     ( $world:expr, $vec:expr, ($name:tt: $type:ty, $($tail:tt)*) ) => {{
         $vec.push(ComponentQuery {
             id: $world.component_registry().id::<$type>().unwrap(),
             mutable: false,
+            optional: false,
         });
         _query_definition!($world, $vec, ($($tail)*));
     }};
+    // mut
     ( $world:expr, $vec:expr, ($name:tt: mut $type:ty, $($tail:tt)*) ) => {{
         $vec.push(ComponentQuery {
             id: $world.component_registry().id::<$type>().unwrap(),
             mutable: true,
+            optional: false,
         });
         _query_definition!($world, $vec, ($($tail)*));
     }};
 
     // Last entry
     ( $world:expr, $vec:expr, ($name:tt: Entity) ) => { };
+    // opt
+    ( $world:expr, $vec:expr, ($name:tt: Option<$type:ty>) ) => {{
+        $vec.push(ComponentQuery {
+            id: $world.component_registry().id::<$type>().unwrap(),
+            mutable: false,
+            optional: true,
+        });
+    }};
+    // mut opt
+    ( $world:expr, $vec:expr, ($name:tt: mut Option<$type:ty>) ) => {{
+        $vec.push(ComponentQuery {
+            id: $world.component_registry().id::<$type>().expect(&format!("{}", std::any::type_name::<$type>())),
+            mutable: true,
+            optional: true,
+        });
+    }};
+    // comp
     ( $world:expr, $vec:expr, ($name:tt: $type:ty) ) => {{
         $vec.push(ComponentQuery {
             id: $world.component_registry().id::<$type>().unwrap(),
             mutable: false,
+            optional: false,
         });
     }};
+    // mut
     ( $world:expr, $vec:expr, ($name:tt: mut $type:ty) ) => {{
         $vec.push(ComponentQuery {
             id: $world.component_registry().id::<$type>().unwrap(),
             mutable: true,
+            optional: false,
         });
     }};
 }
 
 #[macro_export]
 macro_rules! _query_defvars {
+    // Entity
     ( $comps:expr, $lt:expr, $entity:expr, ($name:ident: Entity, $($tail:tt)*) ) => {
         let $name = $entity;
         _query_defvars!($comps[..], $lt, $entity, ($($tail)*));
     };
+    // opt
+    ( $comps:expr, $lt:expr, $entity:expr, ($name:ident: Option<$type:ty>, $($tail:tt)*) ) => {
+        let $name = unsafe { $crate::query::_as_opt_ref_lt($lt, $comps[0].cast::<$type>()) };
+        _query_defvars!($comps[1..], $lt, $entity, ($($tail)*));
+    };
+    // mut opt
+    ( $comps:expr, $lt:expr, $entity:expr, ($name:ident: mut Option<$type:ty>, $($tail:tt)*) ) => {
+        let $name = unsafe { $crate::query::_as_opt_mut_lt($lt, $comps[0].cast::<$type>()) };
+        _query_defvars!($comps[1..], $lt, $entity, ($($tail)*));
+    };
+    // comp
     ( $comps:expr, $lt:expr, $entity:expr, ($name:ident: $type:ty, $($tail:tt)*) ) => {
         let $name = unsafe { $crate::query::_as_ref_lt($lt, $comps[0].cast::<$type>()) };
         _query_defvars!($comps[1..], $lt, $entity, ($($tail)*));
     };
+    // mut
     ( $comps:expr, $lt:expr, $entity:expr, ($name:ident: mut $type:ty, $($tail:tt)*) ) => {
         let $name = unsafe { $crate::query::_as_mut_lt($lt, $comps[0].cast::<$type>()) };
         _query_defvars!($comps[1..], $lt, $entity, ($($tail)*));
@@ -102,9 +164,19 @@ macro_rules! _query_defvars {
     ( $comps:expr, $lt:expr, $entity:expr, ($name:ident: Entity) ) => {
         let $name = $entity;
     };
+    // opt
+    ( $comps:expr, $lt:expr, $entity:expr, ($name:ident: Option<$type:ty>) ) => {
+        let $name = unsafe { $crate::query::_as_opt_ref_lt($lt, $comps[0].cast::<$type>()) };
+    };
+    // opt mut
+    ( $comps:expr, $lt:expr, $entity:expr, ($name:ident: mut Option<$type:ty>) ) => {
+        let $name = unsafe { $crate::query::_as_opt_mut_lt($lt, $comps[0].cast::<$type>()) };
+    };
+    // comp
     ( $comps:expr, $lt:expr, $entity:expr, ($name:ident: $type:ty) ) => {
         let $name = unsafe { $crate::query::_as_ref_lt($lt, $comps[0].cast::<$type>()) };
     };
+    // mut
     ( $comps:expr, $lt:expr, $entity:expr, ($name:ident: mut $type:ty) ) => {
         let $name = unsafe { $crate::query::_as_mut_lt($lt, $comps[0].cast::<$type>()) };
     };
@@ -112,10 +184,28 @@ macro_rules! _query_defvars {
 
 #[macro_export]
 macro_rules! _query_defvars_combs {
+    // entity
     ( $comps1:expr, $comps2:expr, $lt:expr, $entity:expr, ($name:tt: Entity, $($tail:tt)*) ) => {
         let $name = $entity;
         _query_defvars_combs!($comps1, $comps2, $lt, $entity, ($($tail)*));
     };
+    // opt
+    ( $comps1:expr, $comps2:expr, $lt:expr, $entity:expr, ($name:tt: Option<$type:ty>, $($tail:tt)*) ) => {
+        let $name = unsafe { (
+            $crate::query::_as_opt_ref_lt($lt, $comps1[0].cast::<$type>()),
+            $crate::query::_as_opt_ref_lt($lt, $comps2[0].cast::<$type>()),
+        ) };
+        _query_defvars_combs!($comps1[1..], $comps2[1..], $lt, $entity, ($($tail)*));
+    };
+    // opt mut
+    ( $comps1:expr, $comps2:expr, $lt:expr, $entity:expr, ($name:tt: mut Option<$type:ty>, $($tail:tt)*) ) => {
+        let $name = unsafe { (
+            $crate::query::_as_opt_mut_lt($lt, $comps1[0].cast::<$type>()),
+            $crate::query::_as_opt_mut_lt($lt, $comps2[0].cast::<$type>()),
+        ) };
+        _query_defvars_combs!($comps[1..], $lt, $entity, ($($tail)*));
+    };
+    // comp
     ( $comps1:expr, $comps2:expr, $lt:expr, $entity:expr, ($name:tt: $type:ty, $($tail:tt)*) ) => {
         let $name = unsafe { (
             $crate::query::_as_ref_lt($lt, $comps1[0].cast::<$type>()),
@@ -123,6 +213,7 @@ macro_rules! _query_defvars_combs {
         ) };
         _query_defvars_combs!($comps1[1..], $comps2[1..], $lt, $entity, ($($tail)*));
     };
+    // mut
     ( $comps1:expr, $comps2:expr, $lt:expr, $entity:expr, ($name:tt: mut $type:ty, $($tail:tt)*) ) => {
         let $name = unsafe { (
             $crate::query::_as_mut_lt($lt, $comps1[0].cast::<$type>()),
@@ -135,12 +226,14 @@ macro_rules! _query_defvars_combs {
     ( $comps1:expr, $comps2:expr, $lt:expr, $entity:expr, ($name:tt: Entity) ) => {
         let $name = $entity;
     };
+    // comp
     ( $comps1:expr, $comps2:expr, $lt:expr, $entity:expr, ($name:tt: $type:ty) ) => {
         let $name = unsafe { (
             $crate::query::_as_ref_lt($lt, $comps1[0].cast::<$type>()),
             $crate::query::_as_ref_lt($lt, $comps2[0].cast::<$type>()),
         ) };
     };
+    // mut
     ( $comps1:expr, $comps2:expr, $lt:expr, $entity:expr, ($name:tt: mut $type:ty) ) => {
         let $name = unsafe { (
             $crate::query::_as_mut_lt($lt, $comps1[0].cast::<$type>()),
@@ -149,24 +242,24 @@ macro_rules! _query_defvars_combs {
     };
 }
 
-/// Casts `ptr` to a reference with the lifetime `'a`.
-/// # Safety
-/// It is the responsibility of the caller to ensure that the lifetime `'a` outlives
-/// the lifetime of the data pointed to by `ptr`.
-/// # Note
-/// This is used in macros exported by the crate.
 #[allow(clippy::needless_lifetimes)]
-pub unsafe fn _as_ref_lt<'a, T>(_lifetime: &'a (), ptr: NonNull<T>) -> &'a T {
-    ptr.as_ref()
+pub unsafe fn _as_ref_lt<'a, T>(_lifetime: &'a (), ptr: *const T) -> &'a T {
+    &*ptr
 }
 
-/// Casts `ptr` to a mutable reference with the lifetime `'a`.
-/// # Safety
-/// It is the responsibility of the caller to ensure that the lifetime `'a` outlives
-/// the lifetime of the data pointed to by `ptr`.
-/// # Note
-/// This is used in macros exported by the crate.
 #[allow(clippy::mut_from_ref, clippy::needless_lifetimes)]
-pub unsafe fn _as_mut_lt<'a, T>(_lifetime: &'a (), mut ptr: NonNull<T>) -> &'a mut T {
-    ptr.as_mut()
+pub unsafe fn _as_mut_lt<'a, T>(_lifetime: &'a (), ptr: *mut T) -> &'a mut T {
+    &mut *ptr
+}
+
+use std::ptr::NonNull;
+
+#[allow(clippy::needless_lifetimes)]
+pub unsafe fn _as_opt_ref_lt<'a, T>(_lifetime: &'a (), ptr: *const T) -> Option<&'a T> {
+    NonNull::new(ptr as *mut T).map(|ptr| ptr.as_ref())
+}
+
+#[allow(clippy::mut_from_ref, clippy::needless_lifetimes)]
+pub unsafe fn _as_opt_mut_lt<'a, T>(_lifetime: &'a (), ptr: *mut T) -> Option<&'a mut T> {
+    NonNull::new(ptr).map(|mut ptr| ptr.as_mut())
 }

--- a/ecs/src/query/mod.rs
+++ b/ecs/src/query/mod.rs
@@ -86,7 +86,10 @@ impl<'w, 'q> QueryResponse<'w, 'q> {
     /// not marked as mutable in the query is undefined behaviour.
     /// The pointers must not outlive this `QueryResponse`
     pub unsafe fn try_get(&mut self, entity: Entity) -> Option<Vec<NonNull<u8>>> {
-        self.try_get_by_index(entity.get_id_unchecked())
+        self.world
+            .entities()
+            .id(entity)
+            .and_then(|index| self.try_get_by_index(index))
     }
 
     unsafe fn try_get_by_index(&mut self, index: u32) -> Option<Vec<NonNull<u8>>> {

--- a/ecs/src/query/mod.rs
+++ b/ecs/src/query/mod.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashSet, ptr::NonNull};
+use std::collections::HashSet;
 
 use crate::{
     component::{ComponentEntryRef, ComponentId},
@@ -24,6 +24,7 @@ pub struct Query {
 pub struct ComponentQuery {
     pub id: ComponentId,
     pub mutable: bool,
+    pub optional: bool,
 }
 
 impl Query {
@@ -73,7 +74,7 @@ impl<'w, 'q> QueryResponse<'w, 'q> {
     /// Same as `try_get` but panics if `None` would be returned.
     /// # Safety
     /// See documentation for `try_get`
-    pub unsafe fn get(&mut self, entity: Entity) -> Vec<NonNull<u8>> {
+    pub unsafe fn get(&mut self, entity: Entity) -> Vec<*mut u8> {
         self.try_get(entity)
             .expect("The given entity does not match the query or has been despawned")
     }
@@ -85,19 +86,21 @@ impl<'w, 'q> QueryResponse<'w, 'q> {
     /// All pointers returned are technically mutable **BUT** modifying the pointers to components
     /// not marked as mutable in the query is undefined behaviour.
     /// The pointers must not outlive this `QueryResponse`
-    pub unsafe fn try_get(&mut self, entity: Entity) -> Option<Vec<NonNull<u8>>> {
+    pub unsafe fn try_get(&mut self, entity: Entity) -> Option<Vec<*mut u8>> {
         self.world
             .entities()
             .id(entity)
             .and_then(|index| self.try_get_by_index(index))
     }
 
-    unsafe fn try_get_by_index(&mut self, index: u32) -> Option<Vec<NonNull<u8>>> {
+    unsafe fn try_get_by_index(&mut self, index: u32) -> Option<Vec<*mut u8>> {
         let mut res = Vec::with_capacity(self.entries.len());
-        for (e, _) in self.entries.iter().zip(self.query.components().iter()) {
-            res.push(NonNull::new(
-                e.get().storage.get_ptr(index as usize) as *mut _
-            )?);
+        for (e, cq) in self.entries.iter().zip(self.query.components().iter()) {
+            let ptr = e.get().storage.get_ptr(index as usize) as *mut u8;
+            if ptr.is_null() && !cq.optional {
+                return None;
+            }
+            res.push(ptr);
         }
         Some(res)
     }
@@ -125,7 +128,7 @@ impl<'a, 'w, 'q> Iter<'a, 'w, 'q> {
 
 // TODO: for sparse components this could be optimized
 impl<'a, 'r, 'q> Iterator for Iter<'a, 'r, 'q> {
-    type Item = (Entity, Vec<NonNull<u8>>);
+    type Item = (Entity, Vec<*mut u8>);
 
     fn next(&mut self) -> Option<Self::Item> {
         self.entity_iter.next().and_then(|e| unsafe {
@@ -150,19 +153,23 @@ impl<'a, 'w, 'q> IterCombinations<'a, 'w, 'q> {
 
 // TODO: for sparse components this could be optimized
 impl<'a, 'r, 'q> Iterator for IterCombinations<'a, 'r, 'q> {
-    type Item = ((Entity, Vec<NonNull<u8>>), (Entity, Vec<NonNull<u8>>));
+    type Item = ((Entity, Vec<*mut u8>), (Entity, Vec<*mut u8>));
 
     fn next(&mut self) -> Option<Self::Item> {
         // SAFETY: we know that `EntityIterCombinations` won't return the same entity in both
         // values of the tuple, so we know that the components are safe to access.
-        self.entity_iter.next().and_then(|(e1, e2)| unsafe {
-            self.res
-                .try_get_by_index(self.entity_iter.entities().id(e1).unwrap())
-                .and_then(|comps1| {
+        loop {
+            let (e1, e2) = self.entity_iter.next()?;
+            if let (Some(comps1), Some(comps2)) = unsafe {
+                (
                     self.res
-                        .try_get_by_index(self.entity_iter.entities().id(e2).unwrap())
-                        .map(|comps2| ((e1, comps1), (e2, comps2)))
-                })
-        })
+                        .try_get_by_index(self.entity_iter.entities().id(e1).unwrap()),
+                    self.res
+                        .try_get_by_index(self.entity_iter.entities().id(e2).unwrap()),
+                )
+            } {
+                return Some(((e1, comps1), (e2, comps2)));
+            }
+        }
     }
 }


### PR DESCRIPTION
Add support for specifying queries that match even entities that don't have a given component, but still get access to it if it does.

Current syntax looks like this:

```rust
query_iter!(world, (a: A, b: Option<B>) => {
    // a: &A
    // b: Option<&B>
});
query_iter!(world, (a: mut Option<A>) => {
    // a: Option<&mut A>
});
```